### PR TITLE
use sudo to run the pg_dump so that it works with 11.1.3

### DIFF
--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -1,5 +1,8 @@
 directory node[:chef_server_populator][:backup][:dir] do
   recursive true
+  owner 'root'
+  group 'opscode-pgsql'
+  mode  '0775'
 end
 
 #Upload to Remote Storage

--- a/templates/default/chef-server-backup.erb
+++ b/templates/default/chef-server-backup.erb
@@ -16,7 +16,7 @@ data_file = File.join(
               'tar.gz' ].join('.') 
             )
 
-backup_db = system("/opt/chef-server/embedded/bin/pg_dump opscode_chef --username=opscode-pgsql --format=custom > #{db_file}")
+backup_db = system("sudo -i -u opscode-pgsql /opt/chef-server/embedded/bin/pg_dump opscode_chef --username=opscode-pgsql --format=custom -f #{db_file}")
 backup_data = system("tar -czf #{data_file} -C /var/opt/chef-server/bookshelf data")
  
 if backup_db && backup_data


### PR DESCRIPTION
Found that the pg_dump command no longer worked with the 11.1.3 chef-server security patch.

Now sudo-ing to the opscode-pgsql user and allowing group write access to the backup directory.

Also changed to using the -f option for the output file because stdout redirection can have issues under sudo.