### PR TITLE
Fix/client recipe

### DIFF
--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -38,7 +38,7 @@ if(node[:chef_server_populator][:databag])
           execute "set public key for: #{client}" do
             command "#{pg_cmd} -c \"update clients set public_key = E'#{pub_key}' where name = '#{client}'\""
             user 'opscode-pgsql'
-            not_if %Q(sudo -i -u opscode-pgsql #{pg_cmd} -c "select name from clients where name = '#{client}' and public_key = E'#{pub_key}'" -tq | tr -d ' ' | grep '^#{client}$')
+            not_if %Q(sudo -i -u opscode-pgsql #{pg_cmd} -c "select name from clients where name = '#{client}' and public_key = E'#{pub_key.gsub("\n", '\\n')}'" -tq | tr -d ' ' | grep '^#{client}$')
           end
         end
       end

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -3,7 +3,7 @@ include_recipe 'chef-server-populator::configurator'
 knife_cmd = "#{node[:chef_server_populator][:knife_exec]}"
 ssl_port = ''
 if node['chef-server']['configuration']['nginx']['ssl_port']
-  ssl_port = ":#[node['chef-server']['configuration']['nginx']['ssl_port']}"
+  ssl_port = ":#{node['chef-server']['configuration']['nginx']['ssl_port']}"
 end rescue NoMethodError 
 knife_opts = "-k #{node[:chef_server_populator][:pem]} " <<
   "-u #{node[:chef_server_populator][:user]} " <<

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,9 +1,13 @@
 include_recipe 'chef-server-populator::configurator'
 
 knife_cmd = "#{node[:chef_server_populator][:knife_exec]}"
+ssl_port = ''
+if node['chef-server']['configuration']['nginx']['ssl_port']
+  ssl_port = ":#[node['chef-server']['configuration']['nginx']['ssl_port']}"
+end rescue NoMethodError 
 knife_opts = "-k #{node[:chef_server_populator][:pem]} " <<
   "-u #{node[:chef_server_populator][:user]} " <<
-  "-s https://127.0.0.1"
+  "-s https://127.0.0.1#{ssl_port}"
 pg_cmd = "/opt/chef-server/embedded/bin/psql -d opscode_chef"
 
 if(node[:chef_server_populator][:databag])

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -14,6 +14,8 @@ pg_cmd = "/opt/chef-server/embedded/bin/psql -d opscode_chef"
 
 if(node[:chef_server_populator][:databag])
   begin
+    # during testing (with vagrant) the server will be started but not ready to respond to the knife client commands
+    # this will sleep for a maximum of 10 seconds then carry on
     execute 'wait for server' do
       command "counter=1; until [ $counter -gt 10 ] || #{knife_cmd} client list #{knife_opts} > /dev/null 2>&1; do sleep 1; counter=$((counter+1)); do sleep 1; counter=$((counter+1)); done"
       not_if "#{knife_cmd} client list #{knife_opts} > /dev/null 2>&1"

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -17,7 +17,7 @@ if(node[:chef_server_populator][:databag])
     # during testing (with vagrant) the server will be started but not ready to respond to the knife client commands
     # this will sleep for a maximum of 10 seconds then carry on
     execute 'wait for server' do
-      command "counter=1; until [ $counter -gt 10 ] || #{knife_cmd} client list #{knife_opts} > /dev/null 2>&1; do sleep 1; counter=$((counter+1)); do sleep 1; counter=$((counter+1)); done"
+      command "counter=1; until [ $counter -gt 10 ] || #{knife_cmd} client list #{knife_opts} > /dev/null 2>&1; do sleep 1; counter=$((counter+1)); done"
       not_if "#{knife_cmd} client list #{knife_opts} > /dev/null 2>&1"
     end
     data_bag(node[:chef_server_populator][:databag]).each do |item_id|

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -1,10 +1,12 @@
 include_recipe 'chef-server-populator::configurator'
 
 knife_cmd = "#{node[:chef_server_populator][:knife_exec]}"
+
 ssl_port = ''
 if node['chef-server']['configuration']['nginx']['ssl_port']
   ssl_port = ":#{node['chef-server']['configuration']['nginx']['ssl_port']}"
-end rescue NoMethodError 
+end rescue NoMethodError
+
 knife_opts = "-k #{node[:chef_server_populator][:pem]} " <<
   "-u #{node[:chef_server_populator][:user]} " <<
   "-s https://127.0.0.1#{ssl_port}"
@@ -20,7 +22,7 @@ if(node[:chef_server_populator][:databag])
       enabled = item['chef_server']['enabled']
       if(item['enabled'] == false)
         execute "delete client: #{client}" do
-          command "#{knife_cmd} client delete #{client} --admin -d #{knife_opts}"
+          command "#{knife_cmd} client delete #{client} -d #{knife_opts}"
           only_if "#{knife_cmd} client list #{knife_opts}| tr -d ' ' | grep '^#{client}$'"
         end
       else


### PR DESCRIPTION
- use alternative SSL port, if set
- removed the --admin option from "knife client delete..." which would cause it to fail since it's not a valid option
- fixed the not_if guard for setting the client public key to sudo to the opscode-pgsql user and escape the query correctly
- now waits for the chef server to be responsive before dealing with the "knife client..." commands.  Found this was necessary during testing with a new VM, where the server restart was complete but it was not ready to handle requests and would cause an error.