### PR TITLE
Fix for client.rb recipe and update of readme (take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ tmp/
 cookbooks
 Gemfile.lock
 Cheffile.lock
+Berksfile.lock

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Org:
   }
 }
 ```
-Note: Creating the org will create a client called <org>-validator which uses the public key specified when 
+Note: Creating the org will create a client called `<org>-validator` which uses the public key specified when 
 creating the org.
 
 **Restoring from a backup:**

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ support, please pin your environment to version 0.4.0.
 
 ### Usage
 
-When bootstrapping with the chef-server cookbook and chef-solo:
+**When bootstrapping with the chef-server cookbook and chef-solo:**
 
 * Download and unpack chef-server, chef-server-ingredient, packagecloud, and chef-server-populator cookbooks
 * Upload public keys to be used by users, org-validator, and clients (optionally)
@@ -21,7 +21,7 @@ See the `default[:chef_server_populator][:solo_org]` and
 `default[:chef_server_populator][:solo_org_user]` attribute hashes in
 `attributes/default.rb` for the required attribute structure.
 
-When converging with chef-client:
+**When converging with chef-client:**
 
 * Create data bag to hold data bag items with user, org, and client information
 * Create data bag items with user, org, and client information
@@ -89,18 +89,41 @@ Org:
   }
 }
 ```
-Restoring from a backup:
+Note: Creating the org will create a client called <org>-validator which uses the public key specified when 
+creating the org.
+
+**Restoring from a backup:**
 
 * Set path to restore file with node[:chef_server_populator][:restore][:file]
 * The restore recipe is run if a restore file is set
 * The restore file can be remote or local
 
-When enabling backups:
+**When enabling backups:**
 
 * Include chef-server-populator::restore recipe
 * Set backup cron interval with node[:chef_server_populator][:schedule]
 * Optionally set a remote storage location with node[:chef_server_populator][:backup][:remote][:connection]
 * Backups include both a pg_dump of the entire chef database and a tarball of the bookshelf data directory
+
+## Public Key Format
+
+The format of the public key specified with the json object needs to be a single line string with new lines
+represented with the \n character
+
+You can use one of the below commands to convert your public key file into the correct string format (credit
+to the certificates cookbook for these)
+```
+cat <filename> | sed s/$/\\\\n/ | tr -d '\n'
+-OR-
+/usr/bin/env ruby -e 'p ARGF.read' <filename>
+-OR-
+perl -pe 's!(\x0d)?\x0a!\\n!g' <filename>
+```
+If you need to obtain the public key string for your private key first, then run the following on the .pem
+file containing the private key
+```
+openssl rsa -in <path_to_keyfile>.pem -pubout
+```
 
 ## Extras
 

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -78,12 +78,12 @@ if(node[:chef_server_populator][:databag])
           end
           execute 'add org validator key' do
             command "chef-server-ctl add-client-key #{client} #{client}-validator #{key_file} --key-name populator"
-            only_if pub_key
-            not_if "chef-server-ctl list-client-keys #{client} #{client}-validator | grep '^key_name: populator$'"
+            only_if { pub_key }
+            not_if "chef-server-ctl list-client-keys #{client} #{client}-validator | grep '^name: populator$'"
           end
           execute 'remove org default validator key' do
             command "chef-server-ctl delete-client-key #{client} #{client}-validator default"
-            only_if "chef-server-ctl list-client-keys #{client} #{client}-validator | grep '^key_name: default$'"
+            only_if "chef-server-ctl list-client-keys #{client} #{client}-validator | grep '^name: default$'"
           end
         end
 
@@ -96,11 +96,11 @@ if(node[:chef_server_populator][:databag])
           if(pub_key)
             execute "set client key: #{client}" do
               command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{client} #{key_file} --key-name populator"
-              not_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{client} | grep '^key_name: populator$'"
+              not_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{client} | grep '^name: populator$'"
             end
             execute "delete default client key: #{client}" do
               command "chef-server-ctl delete-client-key #{org || node[:chef_server_populator][:default_org]} #{client} default"
-              only_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{client} | grep '^key_name: default$'"
+              only_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{client} | grep '^name: default$'"
             end
           end
         end
@@ -113,11 +113,11 @@ if(node[:chef_server_populator][:databag])
           if(pub_key)
             execute "set user key: #{client}" do
               command "chef-server-ctl add-user-key #{client} #{key_file} --key-name populator"
-              not_if "chef-server-ctl list-user-keys #{client} | grep '^key_name: populator$'"
+              not_if "chef-server-ctl list-user-keys #{client} | grep '^name: populator$'"
             end
             execute "delete default user key: #{client}" do
               command "chef-server-ctl delete-user-key #{client} default"
-              only_if "chef-server-ctl list-user-keys #{client} | grep '^key_name: default$'"
+              only_if "chef-server-ctl list-user-keys #{client} | grep '^name: default$'"
             end
           end
           execute "set user org: #{client}" do


### PR DESCRIPTION
This fix includes:
 * An update to the main README.md to describe
   * how to generate public keys for the data bag items
   * explanation of organisation validator client
 * Fixes for the client.rb recipe
   * A syntax fix on a guard
   * Updates to the grep string for many of the guards on chef-server-ctl which was incorrect
 * Adding Berksfile.lock to .gitignore

Relates to https://github.com/hw-cookbooks/chef-server-populator/pull/10, but removes fix for users/clients attempting to be created before an organisation exists.