### PR TITLE
Consolidate common specs

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -17,6 +17,8 @@ suites:
       - recipe[test]
       - recipe[chef-server-populator]
     attributes:
+      chef-server:
+        version: 12.0.5-1
       chef_server_populator:
         endpoint: localhost
         solo_org:

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -1,41 +1,11 @@
 require_relative './spec_helper'
 
-describe 'chef-server-populator-configurator' do
-
-  describe file('/etc/opscode/pivotal.rb') do
-    it { should be_file }
-  end
+describe 'chef-server-default-org' do
 
   describe file('/etc/opscode/chef-server.rb') do
-    its(:content) { should match /api_fqdn "localhost"/ }
     its(:content) { should match /default_orgname "inception_llc"/ }
   end
 
-end
-
-describe 'chef-server-org-creation' do
-
-  describe command('chef-server-ctl org-list') do
-    its(:stdout) { should match /inception_llc/ }
-  end
-
-  describe command('chef-server-ctl user-list') do
-    its(:stdout) { should match /pivotal\npopulator/ }
-  end
-
-  describe command('chef-server-ctl list-client-keys inception_llc populator') do
-    its(:stdout) { should match /populator/ }
-  end
-
-end
-
-
-describe 'populator-solo-client-creation' do
-
-  describe command('chef-server-ctl list-client-keys inception_llc test-node') do
-    its(:stdout) { should include "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4CeiY3E99UYQFm/xpBJL\nxrmd/zrmCH6yoQva2tXza1+AxOTfSWQcmXWjFMkO1h0w3ElAvieyinRThE9Rl6DE\noGPzJnLzc8AmAMSSdU6gAn8Uto3jQMGk8ByYv+nd1rGMoCl1H29OJuG7g+bkychL\no1sEqQkAn/J+zZ4RHI1E6rXmuEaIRM49j4M0ejh5+zw7YCYiAN/Owz5zrF14P7GL\ni96i5Tek7ndXxAfDOkRiam+I+08rZNspNAVdv0ORHy7sydra/0Y4odC+7f/WrAhE\nHxaPfiUA7/slHmbrZK9/gD7nZf7tpooeaA+nJKVTwWebCVo75APW/KLw7ErYEGyy\n0QIDAQAB\n-----END PUBLIC KEY-----" }
-  end
-  
 end
 
 describe 'chef-server-populator-cookbook-upload' do

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -1,3 +1,39 @@
 require 'serverspec'
 
 set :backend, :exec
+
+describe 'chef-server-populator-configurator' do
+
+  describe file('/etc/opscode/pivotal.rb') do
+    it { should be_file }
+  end
+
+  describe file('/etc/opscode/chef-server.rb') do
+    its(:content) { should match /api_fqdn "localhost"/ }
+  end
+
+end
+
+describe 'chef-server-org-creation' do
+
+  describe command('chef-server-ctl org-list') do
+    its(:stdout) { should match /inception_llc/ }
+  end
+
+  describe command('chef-server-ctl user-list') do
+    its(:stdout) { should match /pivotal\npopulator/ }
+  end
+
+  describe command('chef-server-ctl list-client-keys inception_llc populator') do
+    its(:stdout) { should match /populator/ }
+  end
+
+end
+
+describe 'populator-solo-client-creation' do
+
+  describe command('chef-server-ctl list-client-keys inception_llc test-node') do
+    its(:stdout) { should include "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4CeiY3E99UYQFm/xpBJL\nxrmd/zrmCH6yoQva2tXza1+AxOTfSWQcmXWjFMkO1h0w3ElAvieyinRThE9Rl6DE\noGPzJnLzc8AmAMSSdU6gAn8Uto3jQMGk8ByYv+nd1rGMoCl1H29OJuG7g+bkychL\no1sEqQkAn/J+zZ4RHI1E6rXmuEaIRM49j4M0ejh5+zw7YCYiAN/Owz5zrF14P7GL\ni96i5Tek7ndXxAfDOkRiam+I+08rZNspNAVdv0ORHy7sydra/0Y4odC+7f/WrAhE\nHxaPfiUA7/slHmbrZK9/gD7nZf7tpooeaA+nJKVTwWebCVo75APW/KLw7ErYEGyy\n0QIDAQAB\n-----END PUBLIC KEY-----" }
+  end
+
+end


### PR DESCRIPTION
This moves the common specs--those that check for a test org, client, and user--to the spec_helper so that they can be reused across all suites easily. I also pinned to a known good version of chef-server, because the latest version has a chef-server-ctl bug.