### PR TITLE
Refactor backup and restore for Chef 12

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,6 +9,9 @@ default[:chef_server_populator][:user_databag] = nil
 
 default[:chef_server_populator][:endpoint] = nil
 
+default[:chef_server_populator][:backup_gems][:nokogiri] = '1.6.1'
+default[:chef_server_populator][:backup_gems][:fog] = '1.22.1'
+
 # Deprecated in favor of endpoint
 default[:chef_server_populator][:servername_override] = nil
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -9,8 +9,7 @@ default[:chef_server_populator][:user_databag] = nil
 
 default[:chef_server_populator][:endpoint] = nil
 
-default[:chef_server_populator][:backup_gems][:nokogiri] = '1.6.1'
-default[:chef_server_populator][:backup_gems][:fog] = '1.22.1'
+default[:chef_server_populator][:backup_gems][:miasma] = '~> 0.2'
 
 # Deprecated in favor of endpoint
 default[:chef_server_populator][:servername_override] = nil

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -20,7 +20,7 @@ end
 end
 
 node[:chef_server_populator][:backup_gems].keys.each do |gem_name, gem_version|
-  gem_package g do
+  gem_package gem_name do
     if gem_version
       version gem_version
     end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -19,9 +19,12 @@ end
   end
 end
 
-gem_package 'fog' do
-  only_if{ node[:chef_server_populator][:backup][:remote][:connection] }
-  retries 2
+node[:chef_server_populator][:backup_gems].keys.each do |g|
+  gem_package g do
+    version node[:chef_server_populator][:backup_gems][g]
+    only_if{ node[:chef_server_populator][:backup][:remote][:connection] }
+    retries 2
+  end
 end
 
 directory node[:chef_server_populator][:configuration_directory] do

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -19,9 +19,11 @@ end
   end
 end
 
-node[:chef_server_populator][:backup_gems].keys.each do |g|
+node[:chef_server_populator][:backup_gems].keys.each do |gem_name, gem_version|
   gem_package g do
-    version node[:chef_server_populator][:backup_gems][g]
+    if gem_version
+      version gem_version
+    end
     only_if{ node[:chef_server_populator][:backup][:remote][:connection] }
     retries 2
   end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -43,8 +43,8 @@ file File.join(node[:chef_server_populator][:configuration_directory], 'backup.j
   mode 0600
 end
 
-cookbook_file '/usr/local/bin/chef-server-backup' do
-  source 'chef-server-backup.rb'
+template '/usr/local/bin/chef-server-backup' do
+  source 'chef-server-backup.rb.erb'
   mode '0700'
   retries 3
 end

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -20,7 +20,7 @@ else
 end
 
 execute 'backup chef server stop' do
-  command 'chef-server-ctl stop erchef'
+  command 'chef-server-ctl stop opscode-erchef'
   creates '/etc/opscode/restore.json'
 end
 
@@ -75,11 +75,11 @@ execute 'restore chef server bookshelf start' do
 end
 
 execute 'restore chef server start' do
-  command 'chef-server-ctl start erchef'
+  command 'chef-server-ctl start opscode-erchef'
   creates '/etc/opscode/restore.json'
 end
 
-execute 'restore chef server wait for erchef' do
+execute 'restore chef server wait for opscode-erchef' do
   command 'sleep 10'
   creates '/etc/opscode/restore.json'
 end

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -56,7 +56,12 @@ execute 'remove existing bookshelf data' do
 end
 
 execute 'restore bookshelf data' do
-  command "tar xzf #{data} -C /var/opt/opscode/bookshelf/"
+  command "tar xzf #{data} -C /var/opt/opscode/bookshelf/ data"
+  creates '/etc/opscode/restore.json'
+end
+
+execute 'restore private-chef-secrets.json' do
+  command "tar xzf #{data} -C /etc/opscode/ private-chef-secrets.json"
   creates '/etc/opscode/restore.json'
 end
 

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -85,7 +85,7 @@ execute 'restore chef server wait for opscode-erchef' do
 end
 
 execute 'restore chef server reindex' do
-  command 'chef-server-ctl reindex'
+  command lazy { "chef-server-ctl reindex #{node[:chef_server_populator][:default_org]}" }
   creates '/etc/opscode/restore.json'
 end
 

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -62,7 +62,7 @@ end
 
 execute 'update local superuser cert' do
   command lazy{
-    pivotal_cert = File.read('/etc/opscode/pivotal.cert')
+    pivotal_cert = File.read('/etc/opscode/pivotal.pem')
     "/opt/opscode/embedded/bin/psql -d opscode_chef -c \"update users set public_key=E'#{pivotal_cert}' where username='pivotal'\""
   }
   user 'opscode-pgsql'

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -79,28 +79,23 @@ execute 'update local superuser public key cert' do
   creates '/etc/opscode/restore.json'
 end
 
-execute 'restore chef server bookshelf start' do
-  command 'chef-server-ctl start bookshelf'
+execute 'restore chef server restart' do
+  command 'chef-server-ctl restart'
   creates '/etc/opscode/restore.json'
 end
 
-execute 'restore chef server start' do
-  command 'chef-server-ctl start opscode-erchef'
+execute 'restore restart all chef-server services' do
+  command 'chef-server-ctl restart'
   creates '/etc/opscode/restore.json'
 end
 
 execute 'restore chef server wait for opscode-erchef' do
-  command 'sleep 10'
+  command 'sleep 30'
   creates '/etc/opscode/restore.json'
 end
 
 execute 'restore chef server reindex' do
   command lazy { "chef-server-ctl reindex #{node[:chef_server_populator][:default_org]}" }
-  creates '/etc/opscode/restore.json'
-end
-
-execute 'restore chef server restart' do
-  command 'chef-server-ctl restart'
   creates '/etc/opscode/restore.json'
 end
 

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -57,7 +57,7 @@ execute 'restore chef server wait for opscode-erchef' do
 end
 
 execute 'restore chef server reindex' do
-  command lazy { "chef-server-ctl reindex #{node[:chef_server_populator][:default_org]}" }
+  command "for org in $(chef-server-ctl org-list) ; do chef-server-ctl reindex $org ; done"
   creates '/etc/opscode/restore.json'
 end
 

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -60,9 +60,14 @@ execute 'restore bookshelf data' do
   creates '/etc/opscode/restore.json'
 end
 
-execute 'update local superuser cert' do
+execute 'generate public key certificate for superuser' do
+  command "openssl rsa -in /etc/opscode/pivotal.pem -pubout -out /etc/opscode/pivotal_pub.pem"
+  creates '/etc/opscode/restore.json'
+end
+
+execute 'update local superuser public key cert' do
   command lazy{
-    pivotal_cert = File.read('/etc/opscode/pivotal.pem')
+    pivotal_cert = File.read('/etc/opscode/pivotal_pub.pem')
     "/opt/opscode/embedded/bin/psql -d opscode_chef -c \"update users set public_key=E'#{pivotal_cert}' where username='pivotal'\""
   }
   user 'opscode-pgsql'

--- a/recipes/restore.rb
+++ b/recipes/restore.rb
@@ -37,7 +37,7 @@ execute 'dropping chef database' do
 end
 
 execute 'restoring chef data' do
-  command "/opt/opscode/embedded/bin/pg_restore --create --dbname=postgres #{file}"
+  command "/opt/opscode/embedded/bin/psql -f #{file} postgres"
   user 'opscode-pgsql'
   creates '/etc/opscode/restore.json'
 end

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -57,7 +57,7 @@ begin
 
 
   backup_data = Mixlib::ShellOut.new(
-    "tar -czf #{data_file} -C /var/opt/opscode/bookshelf data -C /etc/opscode private-chef-secrets.json"
+    "tar -czf #{data_file} /var/opt/opscode /etc/opscode"
   )
   backup_data.run_command
   backup_data.error!

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -40,7 +40,7 @@ data_file = File.join(
 )
 
 # stop server
-stop_service = Mixlib::ShellOut.new('chef-server-ctl stop')
+stop_service = Mixlib::ShellOut.new('chef-server-ctl stop erchef')
 stop_service.run_command
 stop_service.error!
 

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -40,7 +40,7 @@ data_file = File.join(
 )
 
 # stop server
-stop_service = Mixlib::ShellOut.new('chef-server-ctl stop erchef')
+stop_service = Mixlib::ShellOut.new('chef-server-ctl stop opscode-erchef')
 stop_service.run_command
 stop_service.error!
 

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require 'fog'
+require 'miasma'
 require 'multi_json'
 require 'mixlib/shellout'
 
@@ -69,18 +69,23 @@ end
 remote_creds = [:remote, :connection].inject(config) do |memo, key|
   memo[key] || break
 end
+
 remote_directory = [:remote, :directory].inject(config) do |memo, key|
   memo[key] || break
 end
 
 if(remote_creds)
   if(remote_directory)
-    remote = Fog::Storage.new(remote_creds)
-    directory = remote.directories.create(:key => remote_directory)
+    remote = Miasma.api(:provider => remote_creds[:provider].to_s.downcase, :type => 'storage', :credentials => remote_creds)
+    directory = remote.buckets.get(remote_directory)
     [db_file, data_file].each do |file|
-      name = File.basename(file)
-      directory.files.create(:key => name, :body => open(file))
-      directory.files.create(:key => "latest#{File.extname(file)}", :body => open(file))
+      remote_file = Miasma::Models::Storage::File.new(directory)
+      remote_file.name = File.basename(file)
+      remote_file.body = File.open(file, 'r')
+      remote_file.save
+
+      remote_file.name = "latest#{File.extname(file)}"
+      remote_file.save
     end
   else
     $stderr.puts 'ERROR: No remote directory defined for backup storage!'

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -79,13 +79,12 @@ if(remote_creds)
     remote = Miasma.api(:provider => remote_creds[:provider].to_s.downcase, :type => 'storage', :credentials => remote_creds)
     directory = remote.buckets.get(remote_directory)
     [db_file, data_file].each do |file|
-      remote_file = Miasma::Models::Storage::File.new(directory)
-      remote_file.name = File.basename(file)
-      remote_file.body = File.open(file, 'r')
-      remote_file.save
-
-      remote_file.name = "latest#{File.extname(file)}"
-      remote_file.save
+      [ :date_stamped, :latest ].each do |type|
+        remote_file = Miasma::Models::Storage::File.new(directory)
+        remote_file.name = type == :date_stamped ? File.basename(file) : "latest#{File.extname(file)}"
+        remote_file.body = File.open(file, 'r')
+        remote_file.save
+      end
     end
   else
     $stderr.puts 'ERROR: No remote directory defined for backup storage!'

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -39,10 +39,12 @@ data_file = File.join(
   "#{prefix}.tgz"
 )
 
-# stop server
-stop_service = Mixlib::ShellOut.new('chef-server-ctl stop opscode-erchef')
-stop_service.run_command
-stop_service.error!
+# stop services that write data we're backing up
+%w( bookshelf opscode-erchef ).each do |svc|
+  stop_service = Mixlib::ShellOut.new("chef-server-ctl stop #{svc}")
+  stop_service.run_command
+  stop_service.error!
+end
 
 begin
   backup = Mixlib::ShellOut.new([

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -39,13 +39,6 @@ data_file = File.join(
   "#{prefix}.tgz"
 )
 
-temp_dir = File.join(
-  config[:dir],
-  'backup'
-)
-
-Dir.mkdir(temp_dir)
-
 # stop services that write data we're backing up
 %w( bookshelf opscode-erchef ).each do |svc|
   stop_service = Mixlib::ShellOut.new("chef-server-ctl stop #{svc}")
@@ -55,7 +48,8 @@ end
 
 begin
   backup = Mixlib::ShellOut.new(
-      "/opt/opscode/embedded/bin/pg_dumpall -c -f #{db_file}"
+      "/opt/opscode/embedded/bin/pg_dumpall -c -f #{db_file}",
+      :user => 'opscode-pgsql'
   )
 
   backup.run_command

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -39,6 +39,13 @@ data_file = File.join(
   "#{prefix}.tgz"
 )
 
+temp_dir = File.join(
+  config[:dir],
+  'backup'
+)
+
+Dir.mkdir(temp_dir)
+
 # stop services that write data we're backing up
 %w( bookshelf opscode-erchef ).each do |svc|
   stop_service = Mixlib::ShellOut.new("chef-server-ctl stop #{svc}")
@@ -47,18 +54,16 @@ data_file = File.join(
 end
 
 begin
-  backup = Mixlib::ShellOut.new([
-      '/opt/opscode/embedded/bin/pg_dump',
-      "opscode_chef --username=opscode-pgsql --format=custom -f #{db_file}"
-    ].join(' '),
-    :user => 'opscode-pgsql'
+  backup = Mixlib::ShellOut.new(
+      "/opt/opscode/embedded/bin/pg_dumpall -c -f #{db_file}"
   )
 
   backup.run_command
   backup.error!
 
+
   backup_data = Mixlib::ShellOut.new(
-    "tar -czf #{data_file} -C /var/opt/opscode/bookshelf data"
+    "tar -czf #{data_file} -C /var/opt/opscode/bookshelf data -C /etc/opscode private-chef-secrets.json"
   )
   backup_data.run_command
   backup_data.error!

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -4,7 +4,7 @@ require 'fog'
 require 'multi_json'
 require 'mixlib/shellout'
 
-DEFAULT_CONFIGURATION_PATH = '/etc/opscode/populator/backup.json'
+DEFAULT_CONFIGURATION_PATH = '<%= node[:chef_server_populator][:configuration_directory] %>/backup.json'
 
 if(ARGV.size > 1 || (ARGV.first && !File.exists?(ARGV.first.to_s)))
   puts 'Usage: chef-server-backup CONFIG_FILE_PATH'


### PR DESCRIPTION
Changes include
* Using [miasma](https://github.com/miasma-rb/miasma) in lieu of fog for remote backup targets
* Backup now dumps all databases, tars up entirety of /var/opt/opscode and /etc/opscode directories
* Chef Server restored from backups is actually usable!