### PR TITLE
[test-kitchen] Fix centos platforms, add ubuntu-14.04

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -8,8 +8,25 @@ provisioner:
   name: chef_solo
 
 platforms:
+  - name: ubuntu-14.04
+    attributes:
+      chef-server:
+        version: 12.0.5-1
   - name: ubuntu-12.04
+    attributes:
+      chef-server:
+        version: 12.0.5-1
+  - name: centos-6.6
+    attributes:
+      chef-server:
+        version: 12.0.5-1.el6
   - name: centos-6.4
+    driver:
+      box: opscode-centos-6.4
+      box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.4_chef-provisionerless.box
+    attributes:
+      chef-server:
+        version: 12.0.5-1.el6
 
 suites:
   - name: default
@@ -17,8 +34,6 @@ suites:
       - recipe[test]
       - recipe[chef-server-populator]
     attributes:
-      chef-server:
-        version: 12.0.5-1
       chef_server_populator:
         endpoint: localhost
         solo_org:

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,5 @@ source "https://rubygems.org"
 
 gem "chef"
 gem "librarian-chef"
-gem "test-kitchen"
-gem "kitchen-vagrant"
+gem "test-kitchen", '~> 1.3.0'
+gem "kitchen-vagrant", '~> 0.16.0'


### PR DESCRIPTION
* Without version constraints on test-kitchen and kitchen-vagrant, we're prone to issues related to t-k/driver incompatibility or where the kitchen-vagrant driver drops supported platforms from [this list](https://github.com/test-kitchen/kitchen-vagrant/blob/66eafa7a0b8b282cdefb6be06bacf2c2081c2f39/lib/kitchen/driver/vagrant.rb#L194-L200).
* Centos platforms need the chef-server version to be specified like '12.0.5-1.el6' whereas Ubuntu is happy with '12.0.5-1', so the chef-server version attributes have been moved up into the platform definitions.