### PR TITLE
Add specs for default, restore and org recipes

### DIFF
--- a/test/unit/default_spec.rb
+++ b/test/unit/default_spec.rb
@@ -1,0 +1,36 @@
+require_relative 'spec_helper'
+
+describe 'chef-server-populator::default' do
+  let(:chef_solo_run) { ChefSpec::SoloRunner.new.converge(described_recipe) }
+  let(:chef_client_run) { ChefSpec::ServerRunner.new.converge(described_recipe) }
+
+  before do
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).and_call_original
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::solo')
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::client')
+    allow_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::restore')
+  end
+
+  context 'when running under chef-solo' do
+    it 'includes solo recipe' do
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::solo')
+      chef_solo_run
+    end
+  end
+
+  context 'when running under chef-client' do
+    it 'includes client recipe' do
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::client')
+      chef_client_run
+    end
+  end
+
+  context 'when provided values for restore file attribute' do
+    it 'includes restore recipe' do
+      chef_solo_run.node.set[:chef_server_populator][:restore][:file] = '/tmp/latest.tgz'
+      expect_any_instance_of(Chef::Recipe).to receive(:include_recipe).with('chef-server-populator::restore')
+      chef_solo_run.converge(described_recipe)
+    end
+  end
+
+end

--- a/test/unit/org_spec.rb
+++ b/test/unit/org_spec.rb
@@ -1,0 +1,114 @@
+require_relative 'spec_helper'
+
+describe 'chef-server-populator::org' do
+
+  let(:default_org) { 'nasa' }
+
+  let(:test_org) {
+    Mash.new(
+      :org_name => 'endurance',
+      :full_name => 'Endurance Shuttle Mission',
+      :validator_pub_key => 'validation_pub.pem'
+    )
+  }
+
+  let(:test_org_user) {
+    Mash.new(
+      :name => 'murph',
+      :first => 'Murphy',
+      :last => 'Cooper',
+      :email => 'murph@nasa.gov'
+    )
+  }
+
+  let(:list_user_keys_cmd) {
+    "chef-server-ctl list-user-keys #{test_org_user[:name]}"
+  }
+
+  let(:list_validator_keys_cmd) {
+    "chef-server-ctl list-client-keys #{test_org[:org_name]} #{test_org[:org_name]}-validator"
+  }
+
+  let(:chef_run) {
+    ChefSpec::ServerRunner.new do |node, _server|
+      node.set[:chef_server_populator][:solo_org] = test_org
+      node.set[:chef_server_populator][:solo_org_user] = test_org_user
+      node.set[:chef_server_populator][:default_org] = default_org
+    end.converge(described_recipe)
+  }
+
+  let(:execute_create_populator_org) {
+    chef_run.execute('create populator org')
+  }
+
+  before do
+    stub_command("chef-server-ctl user-show #{test_org_user[:name]}").and_return(false)
+    stub_command("#{list_user_keys_cmd} | grep 'name: populator$'").and_return(false)
+    stub_command("#{list_user_keys_cmd} | grep 'name: default$'").and_return(false)
+    stub_command("chef-server-ctl org-list | grep '^#{test_org[:org_name]}$'").and_return(false)
+    stub_command("#{list_validator_keys_cmd} | grep 'name: populator$'").and_return(false)
+    stub_command("#{list_validator_keys_cmd} | grep 'name: default$'").and_return(false)
+    stub_command("chef-server-ctl list-client-keys #{test_org[:org_name]} #{test_org[:org_name]}-validator | grep 'name: populator$'").and_return(false)
+        stub_command("chef-server-ctl list-client-keys #{test_org[:org_name]} #{test_org[:org_name]}-validator | grep 'name: default$'").and_return(true)
+  end
+
+  it 'overrides the chef-server default_orgname' do
+    expect(chef_run.node['chef-server'][:configuration][:default_orgname]).to eq(default_org)
+  end
+
+
+  it 'creates the populator user' do
+    expect(chef_run).to run_execute('create populator user')
+  end
+
+  context 'when the populator user has a default key' do
+    it 'deletes the populator user\'s default key' do
+      stub_command("#{list_user_keys_cmd} | grep 'name: default$'").and_return(true)
+      chef_run.converge(described_recipe)
+      expect(chef_run).to run_execute('delete default user key')
+    end
+  end
+
+  context 'when the populator user does not have a default key' do
+    it 'does not delete the populator user\'s default key' do
+      expect(chef_run).to_not run_execute('delete default user key')
+    end
+  end
+
+  context 'when the populator org does not exist' do
+    it 'creates the populator organization' do
+      expect(chef_run).to run_execute('create populator org')
+    end
+
+    context 'when the populator org is also the default org' do
+      it 'notifies chef-server to reconfigure immediately' do
+        chef_run.node.set[:chef_server_populator][:default_org] = test_org[:org_name]
+        chef_run.converge(described_recipe)
+        expect(execute_create_populator_org).to notify('chef_server_ingredient[chef-server-core]').to(:reconfigure).immediately
+      end
+    end
+  end
+
+  context 'when the populator org does not have a "populator" validator key' do
+    it 'adds a validator key for the populator org' do
+      stub_command("#{list_validator_keys_cmd} | grep 'name: populator$'").and_return(false)
+      expect(chef_run).to run_execute('add populator org validator key')
+    end
+  end
+
+  context 'when the populator org has a "populator" validator key' do
+    it 'does not add a validator key for the populator org' do
+      stub_command("#{list_validator_keys_cmd} | grep 'name: populator$'").and_return(true)
+      chef_run.converge(described_recipe)
+      expect(chef_run).to_not run_execute('add populator org validator key')
+    end
+  end
+
+  context 'when the populator org has a default validator key' do
+    it 'removes the populator default validator key' do
+      stub_command("#{list_validator_keys_cmd} | grep 'name: default$'").and_return(true)
+      chef_run.converge(described_recipe)
+      expect(chef_run).to run_execute('remove populator org default validator key')
+    end
+  end
+end

--- a/test/unit/restore_spec.rb
+++ b/test/unit/restore_spec.rb
@@ -1,0 +1,97 @@
+require_relative 'spec_helper'
+
+describe 'chef-server-populator::restore' do
+  let(:restore_path) { '/tmp/chef_restore' }
+  let(:restore_lock) { '/etc/opscode/restore.json' }
+  let(:db_restore_user) { 'opscode-pgsql' }
+  let(:chef_run) do
+    ChefSpec::SoloRunner.new do |node|
+      node.set[:chef_server_populator][:restore][:local_path] = restore_path
+    end.converge(described_recipe)
+  end
+
+  context 'when provided a URL for the database dump' do
+    it 'downloads the remote file' do
+      chef_run.node.set[:chef_server_populator][:restore][:file] = 'https://www.example.com/restore.dump'
+      chef_run.converge(described_recipe)
+      expect(chef_run).to create_remote_file(File.join(restore_path, 'chef_database_restore.dump'))
+    end
+  end
+
+  context 'when provided a URL for the tarball' do
+    it 'downloads the remote file' do
+      chef_run.node.set[:chef_server_populator][:restore][:data] = 'https://www.example.com/restore.tgz'
+      chef_run.converge(described_recipe)
+      expect(chef_run).to create_remote_file(File.join(restore_path, 'chef_data_restore.tar.gz'))
+    end
+  end
+
+  context 'when provided a local path for the database dump' do
+    it 'does not download a remote file' do
+      expect(chef_run).to_not create_remote_file(File.join(restore_path, 'chef_data_restore.dump'))
+    end
+  end
+
+  context 'when provided a local path for the tarball' do
+    it 'does not download a remote file' do
+      expect(chef_run).to_not create_remote_file(File.join(restore_path, 'chef_data_restore.tar.gz'))
+    end
+  end
+
+  it 'stops all chef server services before restoring' do
+    expect(chef_run).to run_execute('backup chef server stop').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'starts postgres before restoring' do
+    expect(chef_run).to run_execute('restore chef server start postgres').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'restores database dump to postgres' do
+    expect(chef_run).to run_execute('restoring chef data').with(
+      :user => db_restore_user,
+      :creates => restore_lock
+    )
+  end
+
+  it 'removes existing data' do
+    expect(chef_run).to run_execute('remove existing data').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'restores data from tarball' do
+    expect(chef_run).to run_execute('restore tarball data').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'restarts all chef server services' do
+    expect(chef_run).to run_execute('restore chef server restart').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'pauses to give opscode-erchef time to start' do
+    expect(chef_run).to run_execute('restore chef server wait for opscode-erchef').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'reindexes all orgs on the server' do
+    expect(chef_run).to run_execute('restore chef server reindex').with(
+      :creates => restore_lock
+    )
+  end
+
+  it 'creates directory for restore lockfile' do
+    expect(chef_run).to create_directory(File.dirname(restore_lock))
+  end
+
+  it 'creates restore lockfile' do
+    expect(chef_run).to render_file(restore_lock)
+  end
+end


### PR DESCRIPTION
FYI the following test in org specs is known to be failing:
```
  when the populator org does not exist
    creates the populator organization
    when the populator org is also the default org
      notifies chef-server to reconfigure immediately (FAILED - 1)
```

PR to address this failure will follow.