### PR TITLE
Make implicit chef server recipe dependency explicit

### DIFF
--- a/recipes/org.rb
+++ b/recipes/org.rb
@@ -1,3 +1,5 @@
+include_recipe 'chef-server'
+
 conf_dir = node[:chef_server_populator][:base_path]
 node.set['chef-server'][:configuration][:default_orgname] = node[:chef_server_populator][:default_org]
 


### PR DESCRIPTION
Resolves failing test in org recipe specs.

Notifying `chef_server_ingredient[chef-server-core]` creates an implicit
dependency on the 'chef-server' recipe, so lets avoid any confusion by
including it explicitly.