### PR TITLE
Fix backups

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,8 @@ creating the org.
 
 **When enabling backups:**
 
-* Include chef-server-populator::restore recipe
-* Set backup cron interval with node[:chef_server_populator][:schedule]
+* Include chef-server-populator::backups recipe
+* Set backup cron interval with node[:chef_server_populator][:backup][:schedule]
 * Optionally set a remote storage location with node[:chef_server_populator][:backup][:remote][:connection]
 * Backups include both a pg_dump of the entire chef database and a tarball of the Chef data directory
 

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -56,5 +56,5 @@ cron 'Chef Server Backups' do
   node[:chef_server_populator][:backup][:schedule].each do |k,v|
     send(k,v)
   end
-  path "$PATH:/opt/chef/embedded/bin/"
+  path "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chef/embedded/bin/"
 end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -56,5 +56,5 @@ cron 'Chef Server Backups' do
   node[:chef_server_populator][:backup][:schedule].each do |k,v|
     send(k,v)
   end
-  path "/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/chef/embedded/bin/"
+  path "/opt/chef/embedded/bin/:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 end

--- a/templates/default/chef-server-backup.rb.erb
+++ b/templates/default/chef-server-backup.rb.erb
@@ -25,7 +25,7 @@ server_manifest = MultiJson.load(
 
 prefix = [
   Time.now.to_i,
-  "ver_#{server_manifest[:version]}",
+  "ver_#{server_manifest[:build_version]}",
   config[:filename]
 ].join('-')
 
@@ -57,7 +57,7 @@ begin
 
 
   backup_data = Mixlib::ShellOut.new(
-    "tar -czf #{data_file} /var/opt/opscode /etc/opscode"
+    "tar -czf #{data_file} --exclude=/var/opt/opscode/rabbitmq/log --exclude=/var/opt/opscode/postgresql/*/data /var/opt/opscode /etc/opscode"
   )
   backup_data.run_command
   backup_data.error!


### PR DESCRIPTION
I found your chef-server-populator cookbook quite useful when standing up a new Chef 12 server, but there are some issues with the backup scripts that I ran into.  This PR fixes the problems that I had; I'm not using the miasma remote backup, so there may be other issues, but with these local backups should work.
