### PR TITLE
Address recent breaking chef-server-ctl changes while maintaining backwards compatibility

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -23,14 +23,14 @@ platforms:
   - name: centos-6.6
     attributes:
       chef-server:
-        version: 12.0.7-1.el6
+        version: 12.0.7-1
   - name: centos-6.4
     driver:
       box: opscode-centos-6.4
       box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.4_chef-provisionerless.box
     attributes:
       chef-server:
-        version: 12.0.5-1.el6
+        version: 12.0.5-1
 
 suites:
   - name: default

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -46,6 +46,21 @@ suites:
           pub_key: user_pub.pem
         clients:
           test-node: client_key_pub.pem
+  - name: default-old-chef
+    run_list:
+      - recipe[test]
+      - recipe[chef-server-populator]
+    attributes:
+      chef-server:
+        version: 12.0.7-1
+      chef_server_populator:
+        endpoint: localhost
+        solo_org:
+          validator_pub_key: validator_pub.pem
+        org_users:
+          pub_key: user_pub.pem
+        clients:
+          test-node: client_key_pub.pem
   - name: data-bag
     provisioner:
       name: chef_zero
@@ -54,6 +69,19 @@ suites:
       - recipe[test]
       - recipe[chef-server-populator]
     attributes:
+      chef_server_populator:
+        endpoint: localhost
+        databag: chef
+  - name: data-bag-old-chef
+    provisioner:
+      name: chef_zero
+    data_bags_path: test/fixtures/data_bags
+    run_list:
+      - recipe[test]
+      - recipe[chef-server-populator]
+    attributes:
+      chef-server:
+        version: 12.0.7-1
       chef_server_populator:
         endpoint: localhost
         databag: chef

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -13,24 +13,24 @@ platforms:
       - recipe[apt]
     attributes:
       chef-server:
-        version: 12.0.7-1
+        version: 12.1.2-1
   - name: ubuntu-12.04
     run_list:
       - recipe[apt]
     attributes:
       chef-server:
-        version: 12.0.7-1
+        version: 12.1.2-1
   - name: centos-6.6
     attributes:
       chef-server:
-        version: 12.0.7-1
+        version: 12.1.2-1.el6
   - name: centos-6.4
     driver:
       box: opscode-centos-6.4
       box_url: http://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_centos-6.4_chef-provisionerless.box
     attributes:
       chef-server:
-        version: 12.0.5-1
+        version: 12.1.2-1.el6
 
 suites:
   - name: default

--- a/README.md
+++ b/README.md
@@ -37,9 +37,9 @@ User:
 ```json
 {
   "id": "user_name",
-  "full_name": "User Name",
-  "email": "name@domain.tld",
   "chef_server": {
+    "full_name": "User Name",
+    "email": "name@domain.tld",
     "client_key": "public key contents",
     "type": [
       "user"
@@ -79,8 +79,8 @@ Org:
 ```json
 {
   "id": "org_name",
-  "full_name": "Organization Name",
   "chef_server": {
+    "full_name": "Organization Name",
     "client_key": "public key contents",
     "type": [
       "org"
@@ -91,6 +91,8 @@ Org:
 ```
 Note: Creating the org will create a client called `<org>-validator` which uses the public key specified when 
 creating the org.
+In addition, there is currently a bug in Chef server 12.1 which means only the first word in
+the full name will be used, as the option is not parsed correctly
 
 **Restoring from a backup:**
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -27,7 +27,7 @@ default[:chef_server_populator][:restore][:local_path] = '/tmp/'
 
 default[:chef_server_populator][:backup][:dir] = '/tmp/chef-server/backup'
 default[:chef_server_populator][:backup][:filename] = 'chef-server-full'
-default[:chef_server_populator][:backup][:remote][:connection] = {}
+default[:chef_server_populator][:backup][:remote][:connection] = nil
 default[:chef_server_populator][:backup][:remote][:directory] = nil
 default[:chef_server_populator][:backup][:remote][:file_prefix] = nil
 default[:chef_server_populator][:backup][:schedule] = {

--- a/examples/chef-12-server.erb
+++ b/examples/chef-12-server.erb
@@ -1,7 +1,7 @@
 ##### Example bootstrap template #####
-# This bootstrap will create a brand new erchef server and
-# use your existing settings to set things up. It will automatically
-# disable the webui, create a client named after the client in
+# This bootstrap will create a brand new chef 12 server and
+# use your existing settings to set things up. It will create
+# a client named after the client in
 # your existing configuration, and update the public keys for your
 # client, as well as the chef-validator. Afterwards, it will install
 # the cookbooks it requires for itself, and then register itself with
@@ -38,7 +38,7 @@ EOP
 ) > /tmp/chef-server-setup/user_pub.pem
 
 mkdir -p /etc/chef
-cp /tmp/chef-server-setup/validation.pem /etc/chef/validation.pem
+cp /tmp/chef-server-setup/validator.pem /etc/chef/validator.pem
 chmod 600 /etc/chef/validator.pem
 
 IPADDR=`curl http://169.254.169.254/latest/meta-data/public-ipv4`

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -49,7 +49,7 @@ if(node[:chef_server_populator][:databag])
           end
         end
         execute "add org validator key: #{item['client']}" do
-          command "chef-server-ctl add-client-key #{item['client']} #{item['client']}-validator #{key_file} --key-name populator"
+          command "chef-server-ctl add-client-key #{item['client']} #{item['client']}-validator --public-key-path #{key_file} --key-name populator"
           not_if "chef-server-ctl list-client-keys #{item['client']} #{item['client']}-validator | grep 'name: populator$'"
         end
         execute "remove org default validator key: #{item['client']}" do
@@ -99,7 +99,7 @@ if(node[:chef_server_populator][:databag])
         end
         if(item['pub_key'])
           execute "set user key: #{item['client']}" do
-            command "chef-server-ctl add-user-key #{item['client']} #{key_file} --key-name populator"
+            command "chef-server-ctl add-user-key #{item['client']} --public-key-path #{key_file} --key-name populator"
             not_if "chef-server-ctl list-user-keys #{item['client']} | grep 'name: populator$'"
           end
           execute "delete default user key: #{item['client']}" do
@@ -150,7 +150,7 @@ if(node[:chef_server_populator][:databag])
         end
         if(item['pub_key'])
           execute "set client key: #{item['client']}" do
-            command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} #{key_file} --key-name populator"
+            command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} --public-key-path #{key_file} --key-name populator"
             not_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{item['client']} | grep 'name: populator$'"
           end
           execute "delete default client key: #{item['client']}" do

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -21,7 +21,7 @@ if(node[:chef_server_populator][:databag])
                  'pub_key' => item['client_key'],
                  'enabled' => item['enabled'],
                  'admin' => item.fetch('admin', false),
-                 'password' => item.fetch('password', SecureRandom.urlsafe_base64(23)),
+                 'password' => item.fetch('password', SecureRandom.urlsafe_base64(23).gsub(/^\-*/,'')),
                  'orgs' => item.fetch('orgs', {}))
     end
     orgs = items.select { |item| item.fetch('type', []).include?('org') }

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -150,8 +150,12 @@ if(node[:chef_server_populator][:databag])
         end
         if(item['pub_key'])
           execute "set client key: #{item['client']}" do
-            command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} --public-key-path #{key_file} --key-name populator"
-            not_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{item['client']} | grep 'name: populator$'"
+            if node['chef-server'][:version].to_f >= 12.1
+              command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} --public-key-path #{key_file} --key-name populator"
+            else
+              command "chef-server-ctl add-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} #{key_file} --key-name populator"
+            end
+              not_if "chef-server-ctl list-client-keys #{org || node[:chef_server_populator][:default_org]} #{item['client']} | grep 'name: populator$'"
           end
           execute "delete default client key: #{item['client']}" do
             command "chef-server-ctl delete-client-key #{org || node[:chef_server_populator][:default_org]} #{item['client']} default"

--- a/recipes/org.rb
+++ b/recipes/org.rb
@@ -31,7 +31,11 @@ execute 'create populator org' do
 end
 
 execute 'add populator org validator key' do
-  command "chef-server-ctl add-client-key #{org[:org_name]} #{org[:org_name]}-validator #{conf_dir}/#{org[:validator_pub_key]} --key-name populator"
+  if node['chef-server'][:version].to_f >= 12.1
+    command "chef-server-ctl add-client-key #{org[:org_name]} #{org[:org_name]}-validator --public-key-path #{conf_dir}/#{org[:validator_pub_key]} --key-name populator"
+  else
+    command "chef-server-ctl add-client-key #{org[:org_name]} #{org[:org_name]}-validator #{conf_dir}/#{org[:validator_pub_key]} --key-name populator"
+      end
   not_if "chef-server-ctl list-client-keys #{org[:org_name]} #{org[:org_name]}-validator | grep 'name: populator$'"
 end
 

--- a/recipes/org.rb
+++ b/recipes/org.rb
@@ -5,7 +5,7 @@ node.set['chef-server'][:configuration][:default_orgname] = node[:chef_server_po
 
 org = node[:chef_server_populator][:solo_org]
 user = node[:chef_server_populator][:solo_org_user]
-pass = user[:pass] || SecureRandom.base64
+pass = user[:pass] || SecureRandom.urlsafe_base64(23).gsub(/^\-*/,'')
 
 execute 'create populator user' do
   command "chef-server-ctl user-create #{user[:name]} #{user[:first]} #{user[:last]} #{user[:email]} #{pass}"

--- a/recipes/solo.rb
+++ b/recipes/solo.rb
@@ -56,7 +56,11 @@ else
         only_if "chef-server-ctl list-client-keys #{node[:chef_server_populator][:server_org]} #{client} | grep 'name: default$'"
       end
       execute "set public key for: #{client}" do
+      if node['chef-server'][:version].to_f >= 12.1
+        command "chef-server-ctl add-client-key #{node[:chef_server_populator][:server_org]} #{client} --public-key-path #{pub_key_path} --key-name populator"
+      else
         command "chef-server-ctl add-client-key #{node[:chef_server_populator][:server_org]} #{client} #{pub_key_path} --key-name populator"
+      end
         not_if "chef-server-ctl list-client-keys #{node[:chef_server_populator][:server_org]} #{client} | grep 'name: populator$'"
       end
     end

--- a/test/fixtures/data_bags/chef/test-user.json
+++ b/test/fixtures/data_bags/chef/test-user.json
@@ -1,7 +1,8 @@
 {
-  "id": "populator",
-  "full_name": "Populator User",
+  "id": "test-user",
   "chef_server": {
+    "full_name": "Test User",
+    "email": "testuser@example.com",
     "client_key": "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4CeiY3E99UYQFm/xpBJL\nxrmd/zrmCH6yoQva2tXza1+AxOTfSWQcmXWjFMkO1h0w3ElAvieyinRThE9Rl6DE\noGPzJnLzc8AmAMSSdU6gAn8Uto3jQMGk8ByYv+nd1rGMoCl1H29OJuG7g+bkychL\no1sEqQkAn/J+zZ4RHI1E6rXmuEaIRM49j4M0ejh5+zw7YCYiAN/Owz5zrF14P7GL\ni96i5Tek7ndXxAfDOkRiam+I+08rZNspNAVdv0ORHy7sydra/0Y4odC+7f/WrAhE\nHxaPfiUA7/slHmbrZK9/gD7nZf7tpooeaA+nJKVTwWebCVo75APW/KLw7ErYEGyy\n0QIDAQAB\n-----END PUBLIC KEY-----",
     "type": [
       "user"

--- a/test/integration/data-bag/serverspec/default_spec.rb
+++ b/test/integration/data-bag/serverspec/default_spec.rb
@@ -1,8 +1,15 @@
 require_relative './spec_helper'
 
+describe "Create user with correct fields" do
+  describe command('chef-server-ctl user-show test-user') do
+    its(:exit_status) { should eq 0 }
+    its(:stdout) { should contain 'Test User' }
+    its(:stdout) { should contain 'testuser@example.com' }
+  end
+end
 describe "NO OPs" do
 
-    describe command('chef-server-ctl user-list') do
+  describe command('chef-server-ctl user-list') do
     its(:stdout) { should_not match /non-chef-user/ }
   end
 

--- a/test/integration/helpers/serverspec/spec_helper.rb
+++ b/test/integration/helpers/serverspec/spec_helper.rb
@@ -20,7 +20,7 @@ describe 'chef-server-org-creation' do
     its(:stdout) { should match /inception_llc/ }
   end
 
-  describe command('chef-server-ctl list-client-keys inception_llc populator') do
+  describe command('chef-server-ctl list-user-keys populator') do
     its(:stdout) { should match /populator/ }
   end
 
@@ -41,7 +41,7 @@ end
 
 describe 'populator-solo-client-creation' do
 
-  describe command('chef-server-ctl list-client-keys inception_llc test-node') do
+  describe command('chef-server-ctl list-client-keys inception_llc test-node -v') do
     its(:stdout) { should include "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA4CeiY3E99UYQFm/xpBJL\nxrmd/zrmCH6yoQva2tXza1+AxOTfSWQcmXWjFMkO1h0w3ElAvieyinRThE9Rl6DE\noGPzJnLzc8AmAMSSdU6gAn8Uto3jQMGk8ByYv+nd1rGMoCl1H29OJuG7g+bkychL\no1sEqQkAn/J+zZ4RHI1E6rXmuEaIRM49j4M0ejh5+zw7YCYiAN/Owz5zrF14P7GL\ni96i5Tek7ndXxAfDOkRiam+I+08rZNspNAVdv0ORHy7sydra/0Y4odC+7f/WrAhE\nHxaPfiUA7/slHmbrZK9/gD7nZf7tpooeaA+nJKVTwWebCVo75APW/KLw7ErYEGyy\n0QIDAQAB\n-----END PUBLIC KEY-----" }
   end
 


### PR DESCRIPTION
Address issue #47

Rolls-up #49 and #42

Note on the tests:

All the old-chef-centos tests fail to converge because the package names are incorrect.