### PR TITLE
Update cookbook to support chef-server 4.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
 ## Unreleased
 
-## v.1.2.2
+## v2.0.0
+* Support chef-server 4.x versions
+* Make chef-server constraint tighter to prevent breakage
+* Remove resource notifications to resources outside our recipes
+* Refactor configuration setup to support hash style attribute and auto-convert to string
+
+## v1.2.2
 * Adds test for user key
 * Fixes org recipe user key in 12.1.x
 
-## v.1.2.0
+## v1.2.0
 * Adds support for both 12.0.x and 12.1.x versions, client key
   commands got a new flag which broke things.
 * Prevents randomly generated passwords from starting with a '-' which
@@ -13,7 +19,7 @@
 * Fixes backup recipe when running as cron
 * Updates and extends the integration tests to cover backups
 
-## v.1.1.4
+## v1.1.4
 * Fixes all users created as admins
 * Updates user creation to require explicit enabled setting
 * Updates client admin to default to false

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,4 +4,4 @@ maintainer 'Heavywater'
 maintainer_email 'support@hw-ops.com'
 version '1.2.3'
 
-depends 'chef-server', '>= 3.1.0'
+depends 'chef-server', '~> 4.0'

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -13,10 +13,7 @@ when 'rhel'
   packages = %w(gcc libxml2 libxml2-devel libxslt libxslt-devel patch)
 end
 packages.each do |fog_dep|
-
-  package fog_dep do
-    only_if{ node[:chef_server_populator][:backup][:remote][:connection] }
-  end
+  package fog_dep
 end
 
 node[:chef_server_populator][:backup_gems].each_pair do |gem_name, gem_version|
@@ -24,7 +21,6 @@ node[:chef_server_populator][:backup_gems].each_pair do |gem_name, gem_version|
     if !gem_version.nil?
       version gem_version
     end
-    only_if{ node[:chef_server_populator][:backup][:remote][:connection] }
     retries 2
   end
 end

--- a/recipes/backups.rb
+++ b/recipes/backups.rb
@@ -56,5 +56,5 @@ cron 'Chef Server Backups' do
   node[:chef_server_populator][:backup][:schedule].each do |k,v|
     send(k,v)
   end
-  path "/opt/chef/embedded/bin/:$PATH"
+  path "/opt/chef/embedded/bin/:/usr/bin:/usr/local/bin:/bin"
 end

--- a/recipes/configurator.rb
+++ b/recipes/configurator.rb
@@ -7,7 +7,7 @@ unless(node[:chef_server_populator][:endpoint])
 end
 
 if(node[:chef_server_populator][:endpoint])
-  node.set[:chef_server_populator][:chef_server][:api_fqdn] =
+  node.set['chef-server'][:api_fqdn] =
     node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name] =
     node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip] =
     node.set[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn] =
@@ -15,7 +15,7 @@ if(node[:chef_server_populator][:endpoint])
   node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:url] =
     node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url] = "https://#{node[:chef_server_populator][:endpoint]}"
 else
-  node.set[:chef_server_populator][:chef_server][:api_fqdn] =
+  node.set['chef-server'][:api_fqdn] =
     node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name] =
     node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip] =
     node.set[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn] =

--- a/recipes/configurator.rb
+++ b/recipes/configurator.rb
@@ -1,5 +1,5 @@
-if(node[:chef_server_populator][:chef_server])
-  node.set['chef-server'] = node['chef-server'].merge(node[:chef_server_populator][:chef_server])
+if(node[:chef_server_populator][:default_org])
+  node.default[:chef_server_populator][:chef_server][:configuration][:default_orgname] = node[:chef_server_populator][:default_org]
 end
 
 unless(node[:chef_server_populator][:endpoint])
@@ -7,21 +7,58 @@ unless(node[:chef_server_populator][:endpoint])
 end
 
 if(node[:chef_server_populator][:endpoint])
-  node.set['chef-server'][:api_fqdn] =
-    node.set['chef-server'][:configuration][:nginx][:server_name] =
-    node.set['chef-server'][:configuration][:bookshelf][:vip] =
-    node.set['chef-server'][:configuration][:lb][:api_fqdn] =
-    node.set['chef-server'][:configuration][:lb][:web_ui_fqdn] = node[:chef_server_populator][:endpoint]
-  node.set['chef-server'][:configuration][:nginx][:url] =
-    node.set['chef-server'][:configuration][:bookshelf][:url] = "https://#{node[:chef_server_populator][:endpoint]}"
+  node.set[:chef_server_populator][:chef_server][:api_fqdn] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:lb][:web_ui_fqdn] = node[:chef_server_populator][:endpoint]
+  node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:url] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url] = "https://#{node[:chef_server_populator][:endpoint]}"
 else
-  node.set['chef-server'][:api_fqdn] =
-    node.set['chef-server'][:configuration][:nginx][:server_name] =
-    node.set['chef-server'][:configuration][:bookshelf][:vip] =
-    node.set['chef-server'][:configuration][:lb][:api_fqdn] =
-    node.set['chef-server'][:configuration][:lb][:web_ui_fqdn] = node[:fqdn]
-  node.set['chef-server'][:configuration][:nginx][:url] =
-    node.set['chef-server'][:configuration][:bookshelf][:url] = "https://#{node[:fqdn]}"
+  node.set[:chef_server_populator][:chef_server][:api_fqdn] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:lb][:web_ui_fqdn] = node[:fqdn]
+  node.set[:chef_server_populator][:chef_server][:configuration][:nginx][:url] =
+    node.set[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url] = "https://#{node[:fqdn]}"
 end
+
+mash_maker = lambda do |x|
+  if(x.is_a?(Hash))
+    x = Mash.new(x)
+    x.keys.each do |key|
+      x[key] = mash_maker.call(x[key])
+    end
+  elsif(x.is_a?(Array))
+    x = x.map do |value|
+      mash_maker.call(value)
+    end
+  end
+  x
+end
+
+current_server_config = mash_maker.call(node['chef-server'])
+populator_server_config = mash_maker.call(node[:chef_server_populator][:chef_server] || {})
+
+if(current_server_config[:configuration].is_a?(Hash))
+  populator_server_config[:configuration] = Chef::Mixin::DeepMerge.deep_merge(
+    current_server_config[:configuration],
+    populator_server_config.fetch(:configuration, Mash.new)
+  )
+end
+
+if(populator_server_config[:configuration])
+  populator_server_config[:configuration] = populator_server_config[:configuration].map do |k,v|
+    "#{k}(#{v.inspect})"
+  end.join("\n")
+end
+
+current_server_config.delete(:configuration)
+
+node.set['chef-server'] = Chef::Mixin::DeepMerge.deep_merge(
+  current_server_config,
+  populator_server_config
+)
 
 include_recipe 'chef-server'

--- a/recipes/org.rb
+++ b/recipes/org.rb
@@ -1,7 +1,6 @@
 include_recipe 'chef-server'
 
 conf_dir = node[:chef_server_populator][:base_path]
-node.set['chef-server'][:configuration][:default_orgname] = node[:chef_server_populator][:default_org]
 
 org = node[:chef_server_populator][:solo_org]
 user = node[:chef_server_populator][:solo_org_user]
@@ -26,11 +25,16 @@ execute 'delete default user key' do
   only_if "chef-server-ctl list-user-keys #{user[:name]} | grep 'name: default$'"
 end
 
+execute 'reconfigure for populator org create' do
+  command 'chef-server-ctl reconfigure'
+  action :nothing
+end
+
 execute 'create populator org' do
   command "chef-server-ctl org-create #{org[:org_name]} #{org[:full_name]} -a #{user[:name]}"
   not_if "chef-server-ctl org-list | grep '^#{org[:org_name]}$'"
   if org[:org_name] == node[:chef_server_populator][:default_org]
-    notifies :reconfigure, 'chef_server_ingredient[chef-server-core]', :immediately
+    notifies :run, 'execute[reconfigure for populator org create]', :immediately
   end
 end
 

--- a/recipes/org.rb
+++ b/recipes/org.rb
@@ -1,3 +1,4 @@
+include_recipe 'chef-server-populator::configurator'
 include_recipe 'chef-server'
 
 conf_dir = node[:chef_server_populator][:base_path]

--- a/recipes/solo.rb
+++ b/recipes/solo.rb
@@ -1,8 +1,8 @@
-include_recipe 'chef-server-populator::configurator'
-
 if(node[:chef_server_populator][:default_org].nil?)
   node.default[:chef_server_populator][:default_org] = node[:chef_server_populator][:server_org]
 end
+
+include_recipe 'chef-server-populator::configurator'
 
 # if backup pull files include restore
 

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -3,7 +3,7 @@ require_relative './spec_helper'
 describe 'chef-server-default-org' do
 
   describe file('/etc/opscode/chef-server.rb') do
-    its(:content) { should match /default_orgname "inception_llc"/ }
+    its(:content) { should match /default_orgname\("inception_llc"\)/ }
   end
 
 end

--- a/test/unit/configurator_spec.rb
+++ b/test/unit/configurator_spec.rb
@@ -24,25 +24,25 @@ describe 'chef-server-populator::configurator' do
     end
 
     it 'overrides the values of a number of chef-server attributes with the specified endpoint' do
-      expect(chef_run.node['chef-server'][:configuration][:nginx][:server_name]).to eq(endpoint)
-      expect(chef_run.node['chef-server'][:configuration][:bookshelf][:vip]).to eq(endpoint)
-      expect(chef_run.node['chef-server'][:configuration][:lb][:api_fqdn]).to eq(endpoint)
-      expect(chef_run.node['chef-server'][:configuration][:lb][:web_ui_fqdn]).to eq(endpoint)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name]).to eq(endpoint)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip]).to eq(endpoint)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn]).to eq(endpoint)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:lb][:web_ui_fqdn]).to eq(endpoint)
 
-      expect(chef_run.node['chef-server'][:configuration][:nginx][:url]).to eq("https://#{endpoint}")
-      expect(chef_run.node['chef-server'][:configuration][:bookshelf][:url]).to eq("https://#{endpoint}")
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:url]).to eq("https://#{endpoint}")
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url]).to eq("https://#{endpoint}")
     end
   end
 
   context 'without a specified endpoint' do
     it 'overrides the values of a number of chef-server attributes with the node\'s fqdn' do
-      expect(chef_run.node['chef-server'][:configuration][:nginx][:server_name]).to eq(fqdn)
-      expect(chef_run.node['chef-server'][:configuration][:bookshelf][:vip]).to eq(fqdn)
-      expect(chef_run.node['chef-server'][:configuration][:lb][:api_fqdn]).to eq(fqdn)
-      expect(chef_run.node['chef-server'][:configuration][:lb][:web_ui_fqdn]).to eq(fqdn)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:server_name]).to eq(fqdn)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:vip]).to eq(fqdn)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:lb][:api_fqdn]).to eq(fqdn)
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:lb][:web_ui_fqdn]).to eq(fqdn)
 
-      expect(chef_run.node['chef-server'][:configuration][:nginx][:url]).to eq("https://#{fqdn}")
-      expect(chef_run.node['chef-server'][:configuration][:bookshelf][:url]).to eq("https://#{fqdn}")
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:url]).to eq("https://#{fqdn}")
+      expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url]).to eq("https://#{fqdn}")
     end
   end
 

--- a/test/unit/configurator_spec.rb
+++ b/test/unit/configurator_spec.rb
@@ -31,6 +31,7 @@ describe 'chef-server-populator::configurator' do
 
       expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:url]).to eq("https://#{endpoint}")
       expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url]).to eq("https://#{endpoint}")
+      expect(chef_run.node['chef-server'][:configuration]).to include(endpoint)
     end
   end
 
@@ -43,6 +44,7 @@ describe 'chef-server-populator::configurator' do
 
       expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:nginx][:url]).to eq("https://#{fqdn}")
       expect(chef_run.node[:chef_server_populator][:chef_server][:configuration][:bookshelf][:url]).to eq("https://#{fqdn}")
+      expect(chef_run.node['chef-server'][:configuration]).to include(fqdn)
     end
   end
 

--- a/test/unit/org_spec.rb
+++ b/test/unit/org_spec.rb
@@ -53,7 +53,7 @@ describe 'chef-server-populator::org' do
   end
 
   it 'overrides the chef-server default_orgname' do
-    expect(chef_run.node['chef-server'][:configuration][:default_orgname]).to eq(default_org)
+    expect(chef_run.node['chef-server'][:configuration]).to include(default_org)
   end
 
 
@@ -84,7 +84,7 @@ describe 'chef-server-populator::org' do
       it 'notifies chef-server to reconfigure immediately' do
         chef_run.node.set[:chef_server_populator][:default_org] = test_org[:org_name]
         chef_run.converge(described_recipe)
-        expect(execute_create_populator_org).to notify('chef_server_ingredient[chef-server-core]').to(:reconfigure).immediately
+        expect(execute_create_populator_org).to notify('execute[reconfigure for populator org create]').to(:run).immediately
       end
     end
   end

--- a/test/unit/solo_spec.rb
+++ b/test/unit/solo_spec.rb
@@ -87,7 +87,7 @@ describe 'chef-server-populator::solo' do
   #
 
   it 'overrides the chef-server default_orgname' do
-    expect(chef_run.node['chef-server'][:configuration][:default_orgname]).to eq(default_org)
+    expect(chef_run.node['chef-server'][:configuration]).to include(default_org)
   end
 
   it 'creates the populator user' do
@@ -126,7 +126,7 @@ describe 'chef-server-populator::solo' do
       end
 
       it 'notifies chef-server to reconfigure immediately' do
-        expect(execute_create_populator_org).to notify('chef_server_ingredient[chef-server-core]').to(:reconfigure).immediately
+        expect(execute_create_populator_org).to notify('execute[reconfigure for populator org create]').to(:run).immediately
       end
     end
   end

--- a/test/unit/solo_spec.rb
+++ b/test/unit/solo_spec.rb
@@ -4,6 +4,7 @@ describe 'chef-server-populator::solo' do
   let(:server_org) { 'nasa' }
   let(:default_org) { 'endurance' }
   let(:base_path) { '/tmp/populator' }
+  let(:endpoint) { 'amazing-chef-816064413.us-west-1.elb.amazonaws.com' }
 
   let(:test_org) do
     Mash.new(
@@ -92,6 +93,17 @@ describe 'chef-server-populator::solo' do
 
   it 'creates the populator user' do
     expect(chef_run).to run_execute('create populator user')
+  end
+
+  context 'with a specified endpoint' do
+    before do
+      chef_run.node.set[:chef_server_populator][:endpoint] = endpoint
+      chef_run.converge(described_recipe)
+    end
+
+    it 'overrides the chef server endpoints to specified endpoint' do
+      expect(chef_run.node['chef-server'][:configuration]).to include(endpoint)
+    end
   end
 
   context 'when the populator user has a default key' do


### PR DESCRIPTION
The chef-server 4.0 cookbook introduced a breaking change around
configuration setup by converting a previously Hash typed attribute to
an inline string. Added support for this style of configuration and
removed usage of no longer existing resources for triggering reconfiguration.

This changeset is a breaking change as it attempts to do it's best at
maintaining the old style hash attribute and auto-stringifying but that
introduces issues about where during the compile phase it is evaluated
and all that fun stuff. So, major version bump for this changeset!