### PR TITLE
Fixing unit test for server backups

### DIFF
--- a/test/unit/backups_spec.rb
+++ b/test/unit/backups_spec.rb
@@ -71,7 +71,7 @@ describe 'chef-server-populator::backups' do
       :command => backup_script,
       :minute => backup_schedule[:minute],
       :hour => backup_schedule[:hour],
-      :path => "/opt/chef/embedded/bin/:$PATH"
+      :path => "/opt/chef/embedded/bin/:/usr/bin:/usr/local/bin:/bin"
     )
   end
 


### PR DESCRIPTION
This test fails on my machine. From what I can tell, it probably passes elsewhere by coincidence since the backups recipe hard-codes the path for crontab.