### PR TITLE
Update nellie config to run apt-get update prior to executing existing tests

### DIFF
--- a/.nellie
+++ b/.nellie
@@ -1,5 +1,6 @@
 {
     "commands": [
+        "apt-get update",
         "apt-get install -y libxml2-dev libxslt-dev zlib1g-dev",
         "bundle install --without integration",
         "bundle exec rake"


### PR DESCRIPTION
Updates automated testing steps to ensure `apt-get update` is run before attempting to install packages.
